### PR TITLE
Ignore proxied wildcard records for non-enterprise plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Also, you can find detailed usage information in [USAGE.md](https://github.com/a
 * The `ttl` argument value defaults to `1` (automatic). The value is forced to `1` (automatic), regardless of explicitly set value, if you set the `proxied` argument to `true`.
 * The `proxied` argument value defaults to `false` (for records that support it). You must explicitly set this argument value to `true` for the records that you want to proxy through Cloudflare.
 * The `proxied` argument value is forced to `false` for unsupported record types, regardless of explicitly set value.
+* The `proxied` argument value is forced to `false` for wildcard records for non-enterprise plans, regardless of explicitly set value, because non-enterprise customers can create but not proxy wildcard records.
 * For each record, you need to come up with any valid name and specify it in the `record_name` argument value (see examples [here](https://github.com/alex-feel/terraform-cloudflare-zone/tree/main/examples)).
 
 ## License

--- a/main.tf
+++ b/main.tf
@@ -233,5 +233,5 @@ resource "cloudflare_record" "this" {
   }
   priority = each.value.priority
   ttl      = contains(["A", "AAAA", "CNAME"], each.value.type) && each.value.proxied == true ? 1 : each.value.ttl
-  proxied  = contains(["A", "AAAA", "CNAME"], each.value.type) && each.value.proxied == true ? true : false
+  proxied  = contains(["A", "AAAA", "CNAME"], each.value.type) && each.value.proxied == true ? length(regexall("^\\*{1}", each.value.name)) == 0 || (length(regexall("^\\*{1}", each.value.name)) > 0 && contains(local.avail_starting_with_enterprise, var.plan)) ? true : false : false
 }


### PR DESCRIPTION
Non-enterprise customers can create but not proxy wildcard records.