### PR TITLE
Bump minimum provider version to v3.14.0

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -4,7 +4,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
-| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | >= 3.11.0 |
+| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | >= 3.14.0 |
 
 ## Modules
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = ">= 3.11.0"
+      version = ">= 3.14.0"
     }
   }
 }


### PR DESCRIPTION
More about the reasons in https://github.com/cloudflare/terraform-provider-cloudflare/pull/1583.