### PR TITLE
Set Terraform maximum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The main goals of this module are to simplify the creation of resources in Cloud
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.0, < 1.3.0 |
 | <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | >= 3.18.0 |
 
 ## Supported Resources

--- a/USAGE.md
+++ b/USAGE.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.0, < 1.3.0 |
 | <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | >= 3.18.0 |
 
 ## Modules

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.2.0, < 1.3.0"
 
   required_providers {
     cloudflare = {


### PR DESCRIPTION
Using Terraform v1.3.0 will require module refactoring, as the built-in `defaults` function will be removed. In addition, Terraform v1.3.0 is still in alpha and there is little point in waiting for its release. More at https://github.com/hashicorp/terraform/releases/tag/v1.3.0-alpha20220622.