### PR TITLE
Add support for `account_id` argument

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -25,6 +25,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_zone"></a> [zone](#input\_zone) | The DNS zone name which will be added, e.g. example.com. | `string` | n/a | yes |
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | Account ID to manage the zone resource in. | `string` | n/a | yes |
 | <a name="input_paused"></a> [paused](#input\_paused) | Indicates if the zone is only using Cloudflare DNS services. A true value means the zone will not receive security or performance benefits.<br>Possible values: true, false. | `bool` | `false` | no |
 | <a name="input_jump_start"></a> [jump\_start](#input\_jump\_start) | Automatically attempt to fetch existing DNS records on creation. Ignored after zone is created.<br>Possible values: true, false. | `bool` | `false` | no |
 | <a name="input_plan"></a> [plan](#input\_plan) | The desired plan for the zone. Can be updated once the one is created. Changing this value will create/cancel associated subscriptions.<br>Possible values: "free", "partners\_free", "pro", "partners\_pro", "business", "partners\_business", "enterprise", "partners\_enterprise". | `string` | `"free"` | no |

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -16,7 +16,8 @@ module "acme_com" {
   version = "x.x.x"
 
   # Required
-  zone = "acme.com"
+  account_id = "c2tby9ikk6f0mpa7njg0waa4o2m5jnr3"
+  zone       = "acme.com"
 
   # Optional
   always_online = "off"

--- a/examples/creating-record-using-data-argument/main.tf
+++ b/examples/creating-record-using-data-argument/main.tf
@@ -16,7 +16,8 @@ module "acme_com" {
   version = "x.x.x"
 
   # Required
-  zone = "acme.com"
+  account_id = "c2tby9ikk6f0mpa7njg0waa4o2m5jnr3"
+  zone       = "acme.com"
 
   records = [
     {

--- a/examples/page-rules-with-priorities/main.tf
+++ b/examples/page-rules-with-priorities/main.tf
@@ -16,7 +16,8 @@ module "acme_com" {
   version = "x.x.x"
 
   # Required
-  zone = "acme.com"
+  account_id = "c2tby9ikk6f0mpa7njg0waa4o2m5jnr3"
+  zone       = "acme.com"
 
   # Optional
   records = [

--- a/examples/same-settings-for-any-number-of-domains/main.tf
+++ b/examples/same-settings-for-any-number-of-domains/main.tf
@@ -29,7 +29,8 @@ module "domains" {
   for_each = toset(local.domains)
 
   # Required
-  zone = each.value
+  account_id = "c2tby9ikk6f0mpa7njg0waa4o2m5jnr3"
+  zone       = each.value
 
   # Optional
   always_online = "off"

--- a/examples/stop-email-spoofing-of-parked-domains/main.tf
+++ b/examples/stop-email-spoofing-of-parked-domains/main.tf
@@ -14,8 +14,11 @@ module "acme_com" {
   source = "registry.terraform.io/alex-feel/zone/cloudflare"
   # It is recommended to pin a module to a specific version, available versions can be found at https://github.com/alex-feel/terraform-cloudflare-zone/tags
   version = "x.x.x"
+
   # Required
-  zone = "acme.com"
+  account_id = "c2tby9ikk6f0mpa7njg0waa4o2m5jnr3"
+  zone       = "acme.com"
+
   records = [
     {
       record_name = "txt_spf_wildcard"

--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,7 @@ locals {
 # Cloudflare Zone
 resource "cloudflare_zone" "this" {
   zone       = var.zone
+  account_id = var.account_id
   paused     = var.paused
   jump_start = var.jump_start
   plan       = var.plan

--- a/variables.tf
+++ b/variables.tf
@@ -7,6 +7,11 @@ variable "zone" {
   description = "The DNS zone name which will be added, e.g. example.com."
 }
 
+variable "account_id" {
+  type        = string
+  description = "Account ID to manage the zone resource in."
+}
+
 # Optional
 
 # cloudflare_zone resource


### PR DESCRIPTION
More at https://github.com/cloudflare/terraform-provider-cloudflare/pull/1767. The `account_id` argument is currently optional, but has been made mandatory in preparation for terraform-provider-cloudflare v4.x.x, more at https://github.com/cloudflare/terraform-provider-cloudflare/issues/1646.